### PR TITLE
Fix pysaml2 dependency.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10']  # TODO '3.11'
+        python-version: ['3.10', '3.11']
         ckan-version: ["2.10", "2.11"]
     name: Python ${{ matrix.python-version }} CKAN ${{ matrix.ckan-version }} extension test
 

--- a/ckanext/saml2auth/tests/test_blueprint_get_request.py
+++ b/ckanext/saml2auth/tests/test_blueprint_get_request.py
@@ -227,35 +227,51 @@ class TestGetRequest:
         }
 
     def _generate_cert(self):
-        from saml2.cert import OpenSSLWrapper
+        # Mint a throwaway RSA keypair / self-signed certificate for the SP
+        # using the `cryptography` library directly. We deliberately avoid
+        # pysaml2's saml2.cert.OpenSSLWrapper, which relies on
+        # OpenSSL.crypto.X509Req -- deprecated in pyOpenSSL 24.2.0 and removed
+        # in 26.3.0 (which the fork's pyopenssl>=25.3.0 resolves to). The
+        # extension never generates certificates at runtime, so this keeps
+        # the test compatible with current pyOpenSSL / cryptography releases.
+        import datetime
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
 
-        cert_info_ca = {
-            "cn": "localhost.ca",
-            "country_code": "se",
-            "state": "ac",
-            "city": "umea",
-            "organization": "Test University",
-            "organization_unit": "Deca"
-        }
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
-        osw = OpenSSLWrapper()
-        ca_cert, ca_key = osw.create_certificate(
-            cert_info_ca,
-            request=False,
-            write_to_file=False
+        name = x509.Name([
+            x509.NameAttribute(NameOID.COUNTRY_NAME, u"SE"),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"ac"),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, u"umea"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"Test University"),
+            x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, u"Deca"),
+            x509.NameAttribute(NameOID.COMMON_NAME, u"localhost"),
+        ])
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - datetime.timedelta(days=1))
+            .not_valid_after(now + datetime.timedelta(days=3650))
+            .sign(key, hashes.SHA256())
         )
 
-        cert_str, key_str = osw.create_certificate(cert_info_ca, request=True)
-        re_cert_str = osw.create_cert_signed_certificate(
-            ca_cert,
-            ca_key,
-            cert_str,
-            valid_from=0,
-            valid_to=1
+        key_str = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
         )
+        cert_str = cert.public_bytes(serialization.Encoding.PEM).decode('ascii')
 
         f = open(os.path.join(extras_folder, 'provider1', 'mycert.pem'), 'w')
-        f.write(re_cert_str)
+        f.write(cert_str)
         f.close()
 
         f = open(os.path.join(extras_folder, 'provider1', 'mykey.pem'), 'wb')
@@ -263,7 +279,7 @@ class TestGetRequest:
         f.close()
 
         self.key_str = key_str
-        self.cert_str = re_cert_str
+        self.cert_str = cert_str
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 flake8    # for the CI build
-pysaml2
 packaging>=22.0

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,12 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     namespace_packages=['ckanext'],
 
-    # pysaml2 7.4 requires python 3.9
+    # See pysaml2 dependency
+    # https://github.com/IdentityPython/pysaml2/pull/1021
+    # https://github.com/IdentityPython/pysaml2/pull/1021#issuecomment-4075874429
     install_requires=[
-        'pysaml2>=7.4',
+        'pysaml2 @ git+https://github.com/peppelinux/pysaml2@pplnx-v7.5.4-1',
+
     ],
 
     # If there are data files included in your packages that need to be


### PR DESCRIPTION
We have a problem in the `pysaml2` dependency of `ckanext-saml2auth`.

## Root Cause
- `_lib.GEN_EMAIL` has been removed `pyopenssl` in version 49.0 (https://github.com/pyca/pyopenssl/commit/55653a56f7b2a3c62b5ad74f97bcc4a61c242cbd)
- PyOpenssl is calling `_lib.GEN_EMAIL` from `cryptography` version 48.0 but version 49.0 is installed 
- Installed version of `pyOpenSSL==24.2.1`
- Installed version `pysaml2==7.5.4`
- `pysaml2` does not pin upper version `"cryptography >=3.1",`

`pysaml2` dependencies are wrong since `pyopenssl<24.3.0` will not work with latest `cryptography`:
https://github.com/IdentityPython/pysaml2/blob/master/pyproject.toml

```
dependencies = [
  "cryptography >=3.1",
  "defusedxml",
  "pyopenssl <24.3.0",
  "python-dateutil",
  "requests >=2.0.0,<3.0.0",  # ^2 means compatible with 2.x
  "xmlschema >=2.0.0,<3.0.0"
]
```

## Possible Fix

Looks like this has been addressed in https://github.com/IdentityPython/pysaml2/pull/1021 but it is waiting to be merged.

It has been tested here (look at the `pyproject.toml` file) : https://github.com/italia/iam-proxy-italia/compare/v3.1.1...v3.2.0

## Error
```
ckan_bcie  | CKAN DB already initialized, skipping db init
ckan_bcie  | CKAN db upgrade
ckan_bcie  | Traceback (most recent call last):
ckan_bcie  |   File "/app/venv/bin/ckan", line 10, in <module>
ckan_bcie  |     sys.exit(ckan())
ckan_bcie  |              ^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
ckan_bcie  |     return self.main(*args, **kwargs)
ckan_bcie  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 1077, in main
ckan_bcie  |     with self.make_context(prog_name, args, **extra) as ctx:
ckan_bcie  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 943, in make_context
ckan_bcie  |     self.parse_args(ctx, args)
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/cli/cli.py", line 120, in parse_args
ckan_bcie  |     result = super().parse_args(ctx, args)
ckan_bcie  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 1644, in parse_args
ckan_bcie  |     rest = super().parse_args(ctx, args)
ckan_bcie  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 1408, in parse_args
ckan_bcie  |     value, args = param.handle_parse_result(ctx, opts, args)
ckan_bcie  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 2400, in handle_parse_result
ckan_bcie  |     value = self.process_value(ctx, value)
ckan_bcie  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/click/core.py", line 2362, in process_value
ckan_bcie  |     value = self.callback(ctx, self, value)
ckan_bcie  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/cli/cli.py", line 130, in _init_ckan_config
ckan_bcie  |     _add_ctx_object(ctx, value)
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/cli/cli.py", line 139, in _add_ctx_object
ckan_bcie  |     ctx.obj = CtxObject(path)
ckan_bcie  |               ^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/cli/cli.py", line 56, in __init__
ckan_bcie  |     self.app = make_app(raw_config)
ckan_bcie  |                ^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/config/middleware/__init__.py", line 29, in make_app
ckan_bcie  |     load_environment(conf)
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/config/environment.py", line 68, in load_environment
ckan_bcie  |     p.load_all()
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/plugins/core.py", line 148, in load_all
ckan_bcie  |     load(*plugins)
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/plugins/core.py", line 164, in load
ckan_bcie  |     service = _get_service(plugin)
ckan_bcie  |               ^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckan/plugins/core.py", line 298, in _get_service
ckan_bcie  |     return ep.load()(name=plugin_name)
ckan_bcie  |            ^^^^^^^^^
ckan_bcie  |   File "/home/ckan/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
ckan_bcie  |     module = import_module(match.group('module'))
ckan_bcie  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "/home/ckan/.local/share/uv/python/cpython-3.11.15-linux-x86_64-gnu/lib/python3.11/importlib/__init__.py", line 126, in import_module
ckan_bcie  |     return _bootstrap._gcd_import(name[level:], package, level)
ckan_bcie  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ckan_bcie  |   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
ckan_bcie  |   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
ckan_bcie  |   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
ckan_bcie  |   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
ckan_bcie  |   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
ckan_bcie  |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/ckanext/saml2auth/plugin.py", line 21, in <module>
ckan_bcie  |     from saml2.client_base import LogoutError
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/saml2/client_base.py", line 25, in <module>
ckan_bcie  |     from saml2.entity import Entity
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/saml2/entity.py", line 22, in <module>
ckan_bcie  |     from saml2 import request as saml_request
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/saml2/request.py", line 6, in <module>
ckan_bcie  |     from saml2.response import IncorrectlySigned
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/saml2/response.py", line 44, in <module>
ckan_bcie  |     from saml2.sigver import DecryptError
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/saml2/sigver.py", line 21, in <module>
ckan_bcie  |     from OpenSSL import crypto
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/OpenSSL/__init__.py", line 8, in <module>
ckan_bcie  |     from OpenSSL import SSL, crypto
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/OpenSSL/SSL.py", line 42, in <module>
ckan_bcie  |     from OpenSSL.crypto import (
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/OpenSSL/crypto.py", line 787, in <module>
ckan_bcie  |     class X509Extension:
ckan_bcie  |   File "/app/venv/lib/python3.11/site-packages/OpenSSL/crypto.py", line 871, in X509Extension
ckan_bcie  |     _lib.GEN_EMAIL: "email",
ckan_bcie  |     ^^^^^^^^^^^^^^
ckan_bcie  | AttributeError: module 'lib' has no attribute 'GEN_EMAIL'
ckan_bcie exited with code 1
           ⦿ Watch disabled
```